### PR TITLE
Fixed types length on 64 bit architecture

### DIFF
--- a/source/global.h
+++ b/source/global.h
@@ -34,16 +34,16 @@
 typedef unsigned char *POINTER;
 
 /* UINT2 defines a two byte word */
-typedef unsigned short int UINT2;
+typedef unsigned short UINT2;
 
 /* UINT4 defines a four byte word */
-typedef unsigned long int UINT4;
+typedef unsigned int UINT4;
 
 /* BYTE defines a unsigned character */
 typedef unsigned char BYTE;
 
 /* internal signed value */
-typedef signed long int signeddigit;
+typedef signed int signeddigit;
 
 #ifndef NULL_PTR
 #define NULL_PTR ((POINTER)0)


### PR DESCRIPTION
The fix forces the defined type to correct length in both 32 bit and 64 bit architecture.

Resolves the issue: https://github.com/mort666/RSAEuro/issues/1